### PR TITLE
Fix deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
@@ -27,18 +27,8 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php-versions }}-
-
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-source --no-progress --no-suggest --no-interaction
+      run: composer install --no-progress --no-interaction
 
     - name: Install Phar tools and build deployment artefact.
       run: |


### PR DESCRIPTION
I didn't realize there was a separate deploy workflow. We should clean this up at some point to reduce duplication with the test workflow, and remove the deprecated actions.

Apparently the deploy process requires pushing a tag (rather than cutting a release via the GitHub UI).