### PR TITLE
Bump phpstan to 1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1",
-        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan": "^1.5.0",
         "phpunit/phpunit": "^9.4",
         "php-coveralls/php-coveralls": "^2.0.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80534ed177887c246acd3dfd811145d3",
+    "content-hash": "ff231b7fbbf6173d96e6da60d1b90de7",
     "packages": [
         {
             "name": "composer/semver",
@@ -3573,20 +3573,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.99",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
+                "reference": "2be8dd6dfa09ab1a21c49956ff591979cd5ab29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2be8dd6dfa09ab1a21c49956ff591979cd5ab29e",
+                "reference": "2be8dd6dfa09ab1a21c49956ff591979cd5ab29e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -3596,11 +3596,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -3613,7 +3608,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
+                "source": "https://github.com/phpstan/phpstan/tree/1.5.0"
             },
             "funding": [
                 {
@@ -3633,7 +3628,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-12T20:09:55+00:00"
+            "time": "2022-03-24T18:18:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/LogstreamManager.php
+++ b/src/LogstreamManager.php
@@ -14,7 +14,8 @@ class LogstreamManager
 {
     public const LOGSTREAM_URI = 'wss://logstream.acquia.com:443/ah_websocket/logstream/v1';
 
-    private $input;
+    // $input is currently unused but may be useful in the future.
+    private $input; // @phpstan-ignore-line
     private $output;
     private $logTypes = [];
     private $servers = [];


### PR DESCRIPTION
Replaces #139 

Removing the unused `$input` would require also removing the constructor parameter. Since this is a public class, that would be a breaking change. Seems easier to just ignore it for now.