### PR TITLE
Expose and validate log types

### DIFF
--- a/src/LogstreamCommand.php
+++ b/src/LogstreamCommand.php
@@ -36,16 +36,7 @@ class LogstreamCommand extends Command
                 't',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Log types to stream',
-                [
-                    'bal-request',
-                    'varnish-request',
-                    'apache-request',
-                    'apache-error',
-                    'php-error',
-                    'drupal-watchdog',
-                    'drupal-request',
-                    'mysql-slow'
-                ]
+                array_keys(LogstreamManager::AVAILABLE_TYPES)
             )
             ->addOption(
                 'servers',

--- a/src/LogstreamManager.php
+++ b/src/LogstreamManager.php
@@ -13,6 +13,18 @@ use React\EventLoop\Factory as EventLoop;
 class LogstreamManager
 {
     public const LOGSTREAM_URI = 'wss://logstream.acquia.com:443/ah_websocket/logstream/v1';
+    // To make this future-proof, it would be better to query the logstream API for available streams.
+    // @see https://github.com/typhonius/acquia-logstream/issues/143
+    public const AVAILABLE_TYPES = [
+        'bal-request' => 'Balancer request',
+        'varnish-request' => 'Varnish request',
+        'apache-request' => 'Apache request',
+        'apache-error' => 'Apache error',
+        'drupal-request' => 'Drupal request',
+        'drupal-watchdog' => 'Drupal watchdog',
+        'php-error' => 'PHP error',
+        'mysql-slow' => 'MySQL slow query',
+    ];
 
     // $input is currently unused but may be useful in the future.
     private $input; // @phpstan-ignore-line
@@ -99,9 +111,16 @@ class LogstreamManager
      * Sets log types to filter logs from.
      *
      * @param array $types
+     *
+     * @throws \Exception
      */
     public function setLogTypeFilter(array $types): void
     {
+        foreach ($types as $type) {
+            if (!array_key_exists($type, self::AVAILABLE_TYPES)) {
+                throw new \RuntimeException(sprintf('Invalid log type: (%s)', $type));
+            }
+        }
         $this->logTypes = $types;
     }
 

--- a/src/LogstreamManager.php
+++ b/src/LogstreamManager.php
@@ -20,9 +20,9 @@ class LogstreamManager
         'varnish-request' => 'Varnish request',
         'apache-request' => 'Apache request',
         'apache-error' => 'Apache error',
-        'drupal-request' => 'Drupal request',
-        'drupal-watchdog' => 'Drupal watchdog',
         'php-error' => 'PHP error',
+        'drupal-watchdog' => 'Drupal watchdog',
+        'drupal-request' => 'Drupal request',
         'mysql-slow' => 'MySQL slow query',
     ];
 

--- a/tests/LogstreamManagerTest.php
+++ b/tests/LogstreamManagerTest.php
@@ -28,16 +28,23 @@ class LogstreamManagerTest extends AcquiaLogstreamTestCase
 
     public function testSetLogTypeFilter()
     {
-        $this->logstream->setLogTypeFilter(['apache-access']);
+        $this->logstream->setLogTypeFilter(['apache-request']);
         $property = $this->getPrivateProperty($this->logstream, 'logTypes');
 
-        $this->assertSame($property->getValue($this->logstream), [0 => 'apache-access']);
+        $this->assertSame($property->getValue($this->logstream), [0 => 'apache-request']);
+    }
+
+    public function testSetInvalidLogTypeFilter()
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Invalid log type: (apache-access)');
+        $this->logstream->setLogTypeFilter(['apache-access']);
     }
 
     public function testGetLogTypeFilter()
     {
-        $property = $this->setPrivateProperty($this->logstream, 'logTypes', ['apache-access']);
-        $this->assertSame($this->logstream->getLogTypeFilter(), [0 => 'apache-access']);
+        $property = $this->setPrivateProperty($this->logstream, 'logTypes', ['apache-request']);
+        $this->assertSame($this->logstream->getLogTypeFilter(), [0 => 'apache-request']);
     }
 
     public function testSetDns()


### PR DESCRIPTION
To prevent issues like https://github.com/acquia/cli/issues/875, it would be nice to expose the list of available log types and validate types when a filter is applied.