### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.php]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
I normally use 2 spaces with PHP, so every time I touch this project I'm fighting default PhpStorm settings 😄 

Using editorconfig would enforce this automatically.