### PR TITLE
Update GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     time: "17:00"
     timezone: Australia/Sydney
   open-pull-requests-limit: 99
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  schedule:
+    interval: 'weekly'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,14 +54,14 @@ jobs:
       run: php logstream.phar
 
     - name: Upload artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ runner.os }}-php-${{ matrix.php-versions }}-logstream.phar
         path: logstream.phar
         if-no-files-found: error
 
     - name: Upload code coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ runner.os }}-php-${{ matrix.php-versions }}-phpunit.html
         path: ./tests/logs/phpunit.html


### PR DESCRIPTION
Actions are failing due to a deprecated version