### PR TITLE
Less frequent dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@ updates:
 - package-ecosystem: composer
   directory: "/"
   schedule:
-    interval: daily
-    time: "17:00"
-    timezone: Australia/Sydney
-  open-pull-requests-limit: 99
+    interval: 'weekly'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
 - package-ecosystem: 'github-actions'
   directory: '/'
   schedule:


### PR DESCRIPTION
Dependabot is pretty spammy when run daily, and it's really not necessary for a project like this with so few dependencies.